### PR TITLE
Add encodeAsNull

### DIFF
--- a/src/interfaces/data-type.ts
+++ b/src/interfaces/data-type.ts
@@ -1,6 +1,7 @@
 import type {
   DecodeBinaryFunction,
   EncodeBinaryFunction,
+  EncodeAsNullFunction,
   EncodeTextFunction,
   OID,
   ParseTextFunction,
@@ -17,6 +18,7 @@ export interface DataType {
   isType: (v: any) => boolean;
   parseBinary: DecodeBinaryFunction;
   parseText: ParseTextFunction;
+  encodeAsNull?: EncodeAsNullFunction;
   encodeBinary?: EncodeBinaryFunction;
   encodeText?: EncodeTextFunction;
   encodeCalculateDim?: EncodeCalculateDimFunction;

--- a/src/protocol/frontend.ts
+++ b/src/protocol/frontend.ts
@@ -155,7 +155,7 @@ export class Frontend {
       io.writeUInt16BE(params.length);
       for (let i = 0; i < params?.length; i++) {
         let v = params[i];
-        if (v == null) {
+        if (v === null || v === undefined) {
           io.writeInt32BE(-1);
           continue;
         }
@@ -164,7 +164,12 @@ export class Frontend {
         const dt = dataTypeOid ? args.typeMap.get(dataTypeOid) : undefined;
 
         if (dt) {
-          if (typeof dt.encodeBinary === 'function') {
+          if (typeof dt.encodeAsNull === "function" && dt.encodeAsNull(v, queryOptions)) {
+            io.writeInt32BE(-1);
+            continue;
+          }
+
+          if (typeof dt.encodeBinary === "function") {
             // Set param format to binary
             io.buffer.writeInt16BE(Protocol.DataFormat.binary, formatOffset + i * 2);
             // Preserve data length

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type Callback = (err?: Error, value?: any) => void;
 export type DecodeBinaryFunction = (buf: Buffer, options: DataMappingOptions & Record<string, any>) => any;
 export type EncodeBinaryFunction = (buf: SmartBuffer, v: any, options: DataMappingOptions) => void;
 export type EncodeCalculateDimFunction = (v: any[]) => number[];
+export type EncodeAsNullFunction = (v: any, options: DataMappingOptions) => boolean;
 export type ParseTextFunction = (v: any, options: DataMappingOptions) => any;
 export type EncodeTextFunction = (v: any, options: DataMappingOptions) => string;
 export type AnyParseFunction = ParseTextFunction | DecodeBinaryFunction;


### PR DESCRIPTION
This is a feature request to extend types to allow themselves to be encoded as a `null` instead of their actual value. 

We use this to implement a custom, external 'blob' type and store NULL if the blob is actually empty, and a length+disk pointer otherwise. This way we don't have to build the 'if length is 0, insert null, otherwise the blob' at every insert/update.