### PR TITLE
Adds enough type information to be compatible with noImplicitAny: true

### DIFF
--- a/src/connection/portal.ts
+++ b/src/connection/portal.ts
@@ -47,7 +47,7 @@ export class Portal {
         queryOptions,
       });
       socket.sendFlushMessage();
-      return await socket.capture(async (code: Protocol.BackendMessageCode, msg: any, done: (err?) => void) => {
+      return await socket.capture(async (code: Protocol.BackendMessageCode, msg: any, done: (err?: Error) => void) => {
         switch (code) {
           case Protocol.BackendMessageCode.BindComplete:
             done();
@@ -71,7 +71,7 @@ export class Portal {
       socket.sendDescribeMessage({ type: 'P', name: this.name });
       socket.sendFlushMessage();
       return await socket.capture(
-        async (code: Protocol.BackendMessageCode, msg: any, done: (err?, result?) => void) => {
+        async (code: Protocol.BackendMessageCode, msg: any, done: (err?: Error, result?: any) => void) => {
           switch (code) {
             case Protocol.BackendMessageCode.NoticeResponse:
               break;
@@ -114,8 +114,10 @@ export class Portal {
             case Protocol.BackendMessageCode.DataRow:
               if (Array.isArray(this._columnFormat)) {
                 rows.push(
-                  msg.columns.map((buf: Buffer, i) =>
-                    this._columnFormat[i] === Protocol.DataFormat.text ? buf.toString('utf8') : buf,
+                  msg.columns.map((buf: Buffer, i: number) =>
+                    (this._columnFormat as Protocol.DataFormat[])[i] === Protocol.DataFormat.text
+                      ? buf.toString('utf8')
+                      : buf,
                   ),
                 );
               } else if (this._columnFormat === Protocol.DataFormat.binary) rows.push(msg.columns);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -135,7 +135,7 @@ export const DataTypeOIDs = {
   _jsonb: 3807,
 };
 
-export const DataTypeNames = {
+export const DataTypeNames: Record<string, string> = {
   [DataTypeOIDs.bool]: 'bool',
   [DataTypeOIDs.bytea]: 'bytea',
   [DataTypeOIDs.char]: 'char',

--- a/src/data-types/bytea-type.ts
+++ b/src/data-types/bytea-type.ts
@@ -1,3 +1,4 @@
+// @ts-ignore -- no type definitions for decodeBytea
 import decodeBytea from 'postgres-bytea';
 import { DataTypeOIDs } from '../constants.js';
 import type { DataType } from '../interfaces/data-type.js';

--- a/src/protocol/backend.ts
+++ b/src/protocol/backend.ts
@@ -4,7 +4,7 @@ import { Protocol } from './protocol.js';
 // 1 byte message type, 4 byte frame length
 const HEADER_LENGTH = 5;
 
-const ErrorFieldTypes = {
+const ErrorFieldTypes: Record<string, string> = {
   M: 'message',
   S: 'severity',
   V: 'severity',
@@ -64,7 +64,7 @@ export class Backend {
   }
 }
 
-const MessageParsers = {
+const MessageParsers: Record<string, (io: BufferReader, code: Protocol.BackendMessageCode, len: number) => any> = {
   [Protocol.BackendMessageCode.Authentication]: parseAuthentication,
   [Protocol.BackendMessageCode.BackendKeyData]: parseBackendKeyData,
   [Protocol.BackendMessageCode.CommandComplete]: parseCommandComplete,
@@ -199,15 +199,15 @@ function parseDataRow(io: BufferReader): Protocol.DataRowMessage {
 }
 
 function parseErrorResponse(io: BufferReader): Protocol.ErrorResponseMessage {
-  const out = {} as Protocol.ErrorResponseMessage;
+  const out: Record<string, string> = {};
 
   let fieldType;
   while ((fieldType = io.readLString(1)) !== '\0') {
     const value = io.readCString('utf8');
-    const key = ErrorFieldTypes[fieldType];
+    const key = ErrorFieldTypes[fieldType!];
     if (key) out[key] = value;
   }
-  return out;
+  return out as Protocol.ErrorResponseMessage;
 }
 
 function parseNotificationResponse(io: BufferReader): Protocol.NotificationResponseMessage {

--- a/src/protocol/pg-socket.ts
+++ b/src/protocol/pg-socket.ts
@@ -64,7 +64,7 @@ export class PgSocket extends SafeEventEmitter {
     const options = this.options;
     const socket = (this._socket = new net.Socket());
 
-    const errorHandler = err => {
+    const errorHandler = (err: Error) => {
       this._state = ConnectionState.CLOSED;
       this._removeListeners();
       this._reset();

--- a/src/protocol/sasl.ts
+++ b/src/protocol/sasl.ts
@@ -97,9 +97,9 @@ export namespace SASL {
     return crypto.pbkdf2Sync(text, Buffer.from(salt, 'base64'), iterations, 32, 'sha256');
   };
 
-  const encode64 = str => Buffer.from(str).toString('base64');
+  const encode64 = (str: string) => Buffer.from(str).toString('base64');
 
-  const hmac = function (key, msg): Buffer {
+  const hmac = function (key: Buffer, msg: string): Buffer {
     return crypto.createHmac('sha256', key).update(msg).digest();
   };
 

--- a/src/util/convert-row-to-object.ts
+++ b/src/util/convert-row-to-object.ts
@@ -1,7 +1,7 @@
 import { FieldInfo } from '../interfaces/field-info.js';
 
 export function convertRowToObject(fields: FieldInfo[], row: any[]): any {
-  const out = {};
+  const out: Record<string, unknown> = {};
   const l = row.length;
   let i;
   for (i = 0; i < l; i++) {


### PR DESCRIPTION
This cleans up a bit of postgrejs code to properly work under noImplicitAny: true (or strict: true)

Background: We're vendoring postgrejs so we can easily manage our own patches on top of postgrejs and jump/debug straight into the TS files. But postgrejs is less strict than our own tsconfig.json, and tsc/typedoc do not support enabling/disabling noImplicitAny on a folder/file base. typedoc also refuses to ignore errors, so improving the typings in postgrejs seems the easiest way out