### PR TITLE
Don't fail if husky is not present

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "citest": "c8 mocha",
     "qc": "npm run lint && npm run check",
     "version": "auto-changelog -p && git add CHANGELOG.md",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
husky is listed as devDependency but used as a npm prepare script, which fails when installing without dev packages:

```
$ npm install --omit=dev --foreground-script 

> postgrejs@2.22.4 prepare
> husky

sh: husky: command not found
npm error code 127
npm error command failed
npm error command sh -c husky
```

(prepare will even run when `--ignore-scripts` is set, but that's a NPM issue)